### PR TITLE
Store tag filter persistently when App is stopped, e.g. with force stop ...

### DIFF
--- a/NotePad/src/org/openintents/notepad/noteslist/NotesList.java
+++ b/NotePad/src/org/openintents/notepad/noteslist/NotesList.java
@@ -224,13 +224,6 @@ public class NotesList extends DistributionLibraryListActivity implements
 		getListView().setOnScrollListener(this);
 
 		mLastFilter = null;
-
-		mCursorUtils = new NotesListCursor(this, getIntent());
-
-		// Make sure mAdapter is created here already,
-		// because onPrepareDialog for the Tags dialog may be called
-		// before onResume() is called.
-		checkAdapter();
 		
 		if (savedInstanceState != null) {
 			mLastFilter = savedInstanceState.getString(BUNDLE_LAST_FILTER);
@@ -253,6 +246,13 @@ public class NotesList extends DistributionLibraryListActivity implements
 			if (!savedTag.equals("")) mSelectedTag = savedTag;
 		}	
 
+		mCursorUtils = new NotesListCursor(this, getIntent());
+
+		// Make sure mAdapter is created here already,
+		// because onPrepareDialog for the Tags dialog may be called
+		// before onResume() is called.
+		checkAdapter();
+		
 		if (Intent.ACTION_CREATE_SHORTCUT.equals(intent.getAction())) {
 			setTitle(R.string.title_pick_note_for_shortcut);
 		}
@@ -271,8 +271,13 @@ public class NotesList extends DistributionLibraryListActivity implements
 		Spinner s = (Spinner) findViewById(R.id.tagselection);
 		s.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
 
-			public void onItemSelected(AdapterView<?> arg0, View arg1,
-					int arg2, long arg3) {
+			public void onItemSelected(AdapterView<?> parent, View view,
+					int position, long id) {
+				if (position == 0) {
+					mSelectedTag = null;
+				} else {
+					mSelectedTag = parent.getItemAtPosition(position).toString();
+				}
 				NotesList.this.updateQuery();
 				decryptDelayed();
 			}
@@ -415,6 +420,15 @@ public class NotesList extends DistributionLibraryListActivity implements
 			mAdapter = new NotesListCursorAdapter(this, cursor, mCursorUtils);
 			setListAdapter(mAdapter);
 
+			if (mSelectedTag==null) {
+				Spinner s = (Spinner) findViewById(R.id.tagselection);
+
+				if (s.getSelectedItemPosition() == 0) {
+					mSelectedTag = null;
+				} else {
+					mSelectedTag = (String) s.getSelectedItem();
+				}
+			}
 			updateQuery();
 		} else {
 			mAdapter.getCursor().requery();
@@ -422,14 +436,6 @@ public class NotesList extends DistributionLibraryListActivity implements
 	}
 
 	protected void updateQuery() {
-		Spinner s = (Spinner) findViewById(R.id.tagselection);
-
-		if (s.getSelectedItemPosition() == 0) {
-			mSelectedTag = null;
-		} else {
-			mSelectedTag = (String) s.getSelectedItem();
-		}
-
 		if (debug) {
 			Log.i(TAG, "updateQuery: Lastfilter: " + mLastFilter + ", mSelectedTag: " + mSelectedTag);
 		}

--- a/NotePad/src/org/openintents/notepad/noteslist/NotesList.java
+++ b/NotePad/src/org/openintents/notepad/noteslist/NotesList.java
@@ -85,6 +85,7 @@ import android.widget.ListView;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
+import android.content.SharedPreferences;
 
 /**
  * Displays a list of notes. Will display notes from the {@link Uri} provided in
@@ -112,9 +113,12 @@ public class NotesList extends DistributionLibraryListActivity implements
 																			// LAST
 
 	private static final String BUNDLE_LAST_FILTER = "last_filter";
-
+	private static final String BUNDLE_LAST_TAG = "last_tag";
+	
 	private static final String BUNDLE_CONTEXTMENUINFO_ID = "ctx_menu_id";
 	private static final String BUNDLE_CONTEXTMENUINFO_POSITION = "ctx_menu_position";
+
+    public static final String PREFS_NAME = "NotesListPrefs";
 
 	/**
 	 * A group id for alternative menu items.
@@ -221,8 +225,16 @@ public class NotesList extends DistributionLibraryListActivity implements
 
 		mLastFilter = null;
 
+		mCursorUtils = new NotesListCursor(this, getIntent());
+
+		// Make sure mAdapter is created here already,
+		// because onPrepareDialog for the Tags dialog may be called
+		// before onResume() is called.
+		checkAdapter();
+		
 		if (savedInstanceState != null) {
 			mLastFilter = savedInstanceState.getString(BUNDLE_LAST_FILTER);
+			if(mSelectedTag==null) mSelectedTag = savedInstanceState.getString(BUNDLE_LAST_TAG);
 
 			// Restore information for context menu, for opening "Tags" dialog.
 			if (savedInstanceState.containsKey(BUNDLE_CONTEXTMENUINFO_ID)) {
@@ -233,13 +245,13 @@ public class NotesList extends DistributionLibraryListActivity implements
 						position, id);
 			}
 		}
-
-		mCursorUtils = new NotesListCursor(this, getIntent());
-
-		// Make sure mAdapter is created here already,
-		// because onPrepareDialog for the Tags dialog may be called
-		// before onResume() is called.
-		checkAdapter();
+		// if mSelectedTag was not in memory and not in bundle: try to recover it from persistent storage
+		if(mSelectedTag==null)
+		{
+			SharedPreferences settings = getSharedPreferences(PREFS_NAME, 0);
+			String savedTag = settings.getString(BUNDLE_LAST_TAG, "");
+			if (!savedTag.equals("")) mSelectedTag = savedTag;
+		}	
 
 		if (Intent.ACTION_CREATE_SHORTCUT.equals(intent.getAction())) {
 			setTitle(R.string.title_pick_note_for_shortcut);
@@ -311,10 +323,14 @@ public class NotesList extends DistributionLibraryListActivity implements
 		Collections.sort(taglist, Collator.getInstance(Locale.getDefault()));
 		taglist.add(0, getString(R.string.all_notes));
 		Spinner s = (Spinner) findViewById(R.id.tagselection);
-		ArrayAdapter adapter = new ArrayAdapter(this,
+		ArrayAdapter<String> adapter = new ArrayAdapter<String>(this,
 				android.R.layout.simple_spinner_item, taglist);
 		adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
 		s.setAdapter(adapter);
+		int position = adapter.getPosition(mSelectedTag);
+		if (position != -1)	{
+			s.setSelection(position);
+		}
 
 		// Hide Spinner if there are no tags
 		if (taglist.size() > 1) {
@@ -406,10 +422,6 @@ public class NotesList extends DistributionLibraryListActivity implements
 	}
 
 	protected void updateQuery() {
-		if (debug) {
-			Log.i(TAG, "Lastfilter: " + mLastFilter);
-		}
-
 		Spinner s = (Spinner) findViewById(R.id.tagselection);
 
 		if (s.getSelectedItemPosition() == 0) {
@@ -418,6 +430,10 @@ public class NotesList extends DistributionLibraryListActivity implements
 			mSelectedTag = (String) s.getSelectedItem();
 		}
 
+		if (debug) {
+			Log.i(TAG, "updateQuery: Lastfilter: " + mLastFilter + ", mSelectedTag: " + mSelectedTag);
+		}
+		
 		// if (mLastFilter != null || mSelectedTag != null) {
 		Cursor cursor = mAdapter.runQueryOnBackgroundThread(mLastFilter,
 				mSelectedTag);
@@ -458,6 +474,18 @@ public class NotesList extends DistributionLibraryListActivity implements
 	}
 
 	@Override
+	protected void onStop() {
+		super.onStop();
+		if (debug)
+			Log.d(TAG, "onStop()");
+				
+        SharedPreferences settings = getSharedPreferences(PREFS_NAME, 0);
+        SharedPreferences.Editor editor = settings.edit();
+        editor.putString(BUNDLE_LAST_TAG, mSelectedTag);
+        editor.commit();
+	}
+	
+	@Override
 	protected void onDestroy() {
 		// TODO Auto-generated method stub
 		super.onDestroy();
@@ -469,6 +497,7 @@ public class NotesList extends DistributionLibraryListActivity implements
 		super.onSaveInstanceState(outState);
 
 		outState.putString(BUNDLE_LAST_FILTER, mCursorUtils.mCurrentFilter);
+		outState.putString(BUNDLE_LAST_TAG, mSelectedTag);
 
 		if (mContextMenuInfo != null) {
 			outState.putLong(BUNDLE_CONTEXTMENUINFO_ID, mContextMenuInfo.id);


### PR DESCRIPTION
Fixed a problem in OI Notepad that would cause the currently selected tag filter to get lost when the app was force-closed or the user pressed the back button on the device. The selected tag filter was also lost when the user exited from editing a note by pressing the "Edit note" button at the top left of the edit note activity. As a result, OI Notepad did always switch back to the "All notes" view. For me this was very annoying because I mostly work in one category of notes and don't want to see others most of the time.

This problem occurred in OI Notepad 1.3 and 1.4.0.7.

The fix stores the active tag filter persistently to survive even when the app is stopped or the device is powered off.

I tried to limit the changes to a minimum. The merge should be straight forward.