### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/NotePad/src/main/java/org/openintents/intents/CryptoIntents.java
+++ b/NotePad/src/main/java/org/openintents/intents/CryptoIntents.java
@@ -22,6 +22,8 @@ package org.openintents.intents;
  */
 public class CryptoIntents {
 
+    private CryptoIntents() {}
+
     /**
      * Activity Action: Encrypt all strings given in the extra(s) EXTRA_TEXT or
      * EXTRA_TEXT_ARRAY. Returns all encrypted string in the same extra(s).

--- a/NotePad/src/main/java/org/openintents/intents/FileManagerIntents.java
+++ b/NotePad/src/main/java/org/openintents/intents/FileManagerIntents.java
@@ -26,6 +26,8 @@ package org.openintents.intents;
  */
 public final class FileManagerIntents {
 
+    private FileManagerIntents() {}
+
     /**
      * Activity Action: Pick a file through the file manager, or let user
      * specify a custom file name. Data is the current file name or file name

--- a/NotePad/src/main/java/org/openintents/intents/NotepadIntents.java
+++ b/NotePad/src/main/java/org/openintents/intents/NotepadIntents.java
@@ -8,6 +8,8 @@ package org.openintents.intents;
  */
 public class NotepadIntents {
 
+    private NotepadIntents() {}
+
     /**
      * The text currently selected, if used with
      * CATEGORY_TEXT_SELECTION_ALTERNATIVE.

--- a/NotePad/src/main/java/org/openintents/intents/ProviderIntents.java
+++ b/NotePad/src/main/java/org/openintents/intents/ProviderIntents.java
@@ -10,6 +10,8 @@ package org.openintents.intents;
  */
 public final class ProviderIntents {
 
+    private ProviderIntents() {}
+
     /**
      * Broadcast Action: Sent after a new entry has been inserted.
      * <p/>

--- a/NotePad/src/main/java/org/openintents/notepad/PrivateNotePadIntents.java
+++ b/NotePad/src/main/java/org/openintents/notepad/PrivateNotePadIntents.java
@@ -2,6 +2,8 @@ package org.openintents.notepad;
 
 public class PrivateNotePadIntents {
 
+    private PrivateNotePadIntents() {}
+
     /*
      * Content Provider ID. Private extra that is passed along with an ENCRYPT
      * or DECRYPT intent.

--- a/NotePad/src/main/java/org/openintents/notepad/intents/NotepadInternalIntents.java
+++ b/NotePad/src/main/java/org/openintents/notepad/intents/NotepadInternalIntents.java
@@ -2,6 +2,8 @@ package org.openintents.notepad.intents;
 
 public class NotepadInternalIntents {
 
+    private NotepadInternalIntents() {}
+
     /**
      * Activity action: Save note to SD card.
      * <p/>

--- a/NotePad/src/main/java/org/openintents/notepad/search/FullTextSearch.java
+++ b/NotePad/src/main/java/org/openintents/notepad/search/FullTextSearch.java
@@ -12,6 +12,8 @@ import org.openintents.notepad.PreferenceActivity;
 
 public class FullTextSearch {
 
+    private FullTextSearch() {}
+
     /**
      * The columns we'll include in our search suggestions. There are others
      * that could be used to further customize the suggestions, see the docs in

--- a/NotePad/src/main/java/org/openintents/notepad/theme/ThemeNotepad.java
+++ b/NotePad/src/main/java/org/openintents/notepad/theme/ThemeNotepad.java
@@ -2,6 +2,8 @@ package org.openintents.notepad.theme;
 
 public class ThemeNotepad {
 
+    private ThemeNotepad() {}
+
     // For Notepad theme
     // (move to separate class eventually)
 

--- a/NotePad/src/main/java/org/openintents/notepad/theme/ThemeUtils.java
+++ b/NotePad/src/main/java/org/openintents/notepad/theme/ThemeUtils.java
@@ -40,6 +40,9 @@ import org.xmlpull.v1.XmlPullParserException;
  * @author Peli
  */
 public class ThemeUtils {
+
+    private ThemeUtils() {}
+
     public static final String METADATA_THEMES = "org.openintents.themes";
     public static final String ELEM_THEMES = "themes";
     public static final String ELEM_ATTRIBUTESET = "attributeset";

--- a/NotePad/src/main/java/org/openintents/notepad/util/ExtractTitle.java
+++ b/NotePad/src/main/java/org/openintents/notepad/util/ExtractTitle.java
@@ -2,6 +2,8 @@ package org.openintents.notepad.util;
 
 public class ExtractTitle {
 
+    private ExtractTitle() {}
+
     public static final String extractTitle(String text) {
         int length = text.length();
         String title = text.substring(0, Math.min(30, length));

--- a/NotePad/src/main/java/org/openintents/notepad/util/FileUriUtils.java
+++ b/NotePad/src/main/java/org/openintents/notepad/util/FileUriUtils.java
@@ -26,6 +26,8 @@ import java.io.File;
  */
 public class FileUriUtils {
 
+    private FileUriUtils() {}
+
     /**
      * Convert File into Uri.
      *

--- a/NotePad/src/main/java/org/openintents/notepad/util/SendNote.java
+++ b/NotePad/src/main/java/org/openintents/notepad/util/SendNote.java
@@ -8,6 +8,9 @@ import android.widget.Toast;
 import org.openintents.notepad.R;
 
 public class SendNote {
+
+    private SendNote() {}
+
     public static void sendNote(Activity from, String title, String content) {
         Intent i = new Intent();
         i.setAction(Intent.ACTION_SEND);

--- a/NotePad/src/main/java/org/openintents/util/ProviderUtils.java
+++ b/NotePad/src/main/java/org/openintents/util/ProviderUtils.java
@@ -9,6 +9,8 @@ import android.text.TextUtils;
 
 public class ProviderUtils {
 
+    private ProviderUtils(){}
+
     /**
      * Returns the row IDs of all affected rows.
      *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed