### PR TITLE
Code quality fix - Mutable fields should not be "public static".

### DIFF
--- a/NotePad/src/main/java/org/openintents/notepad/NotePad.java
+++ b/NotePad/src/main/java/org/openintents/notepad/NotePad.java
@@ -145,7 +145,7 @@ public final class NotePad {
          * Support sort orders. The "sort order" in the preferences is an index
          * into this array.
          */
-        public static final String[] SORT_ORDERS = {"title ASC", "title DESC",
+        protected static final String[] SORT_ORDERS = {"title ASC", "title DESC",
                 "modified DESC", "modified ASC", "created DESC", "created ASC"};
 
         // This class cannot be instantiated

--- a/NotePad/src/main/java/org/openintents/notepad/noteslist/NotesListCursor.java
+++ b/NotePad/src/main/java/org/openintents/notepad/noteslist/NotesListCursor.java
@@ -39,7 +39,7 @@ public class NotesListCursor extends OpenMatrixCursor {
     /**
      * This cursors' columns
      */
-    public static final String[] PROJECTION = new String[]{Notes._ID, // 0
+    protected static final String[] PROJECTION = new String[]{Notes._ID, // 0
             Notes.TITLE, // 1
             Notes.TAGS, // 2
             Notes.ENCRYPTED, // 3
@@ -81,14 +81,14 @@ public class NotesListCursor extends OpenMatrixCursor {
     /**
      * Map encrypted titles to decrypted ones.
      */
-    public static HashMap<String, String> mEncryptedStringHashMap = new HashMap<String, String>();
+    protected static HashMap<String, String> mEncryptedStringHashMap = new HashMap<String, String>();
 
     /**
      * List containing all encrypted strings. These are decrypted one at a time
      * while idle. The list is synchronized because background threads may add
      * items to it.
      */
-    public static List<String> mEncryptedStringList = Collections
+    protected static List<String> mEncryptedStringList = Collections
             .synchronizedList(new LinkedList<String>());
 
     public boolean mContainsEncryptedStrings;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2386 - Mutable fields should not be "public static". 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2386

Please let me know if you have any questions.

Faisal Hameed