### PR TITLE
Code quality fix - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.

### DIFF
--- a/NotePad/src/main/java/org/openintents/notepad/NoteEditor.java
+++ b/NotePad/src/main/java/org/openintents/notepad/NoteEditor.java
@@ -680,7 +680,7 @@ public class NoteEditor extends Activity implements ThemeDialogListener {
     }
 
     private String readFile(InputStream inputStream) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
 
         try {
             Reader in = new InputStreamReader(inputStream, "UTF-8");
@@ -1749,8 +1749,9 @@ public class NoteEditor extends Activity implements ThemeDialogListener {
         int newStartPos = startPos;
         int newEndPos;
         ContentValues values = new ContentValues();
+
         String newNote;
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (textBefore != null) {
             sb.append(textBefore);
             newStartPos = textBefore.length();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.

Faisal Hameed