### PR TITLE
Code quality fix - "public static" fields should be constant

### DIFF
--- a/NotePad/src/main/java/org/openintents/notepad/search/SearchSuggestionProvider.java
+++ b/NotePad/src/main/java/org/openintents/notepad/search/SearchSuggestionProvider.java
@@ -51,7 +51,7 @@ public class SearchSuggestionProvider extends ContentProvider {
             SearchManager.SUGGEST_COLUMN_TEXT_2,
             SearchManager.SUGGEST_COLUMN_INTENT_DATA,
             SearchManager.SUGGEST_COLUMN_SHORTCUT_ID};
-    public static String AUTHORITY = "org.openintents.notepad.search.SuggestionProvider";
+    public static final String AUTHORITY = "org.openintents.notepad.search.SuggestionProvider";
     private static final UriMatcher sURIMatcher = buildUriMatcher();
 
     /**

--- a/NotePad/src/main/java/org/openintents/notepad/theme/ThemeUtils.java
+++ b/NotePad/src/main/java/org/openintents/notepad/theme/ThemeUtils.java
@@ -51,7 +51,7 @@ public class ThemeUtils {
     public static final String ATTR_STYLE = "style";
     private static final String TAG = "ThemeUtils";
     private static final boolean debug = false;
-    public static String SCHEMA = "http://schemas.openintents.org/android/themes";
+    public static final String SCHEMA = "http://schemas.openintents.org/android/themes";
 
     public static int[] getAttributeIds(Context context, String[] attrNames,
                                         String packageName) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1444 - "public static" fields should be constant
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1444

Please let me know if you have any questions.

Faisal Hameed