### PR TITLE
Update WrapActionBar.java

### DIFF
--- a/NotePad/src/main/java/org/openintents/notepad/wrappers/WrapActionBar.java
+++ b/NotePad/src/main/java/org/openintents/notepad/wrappers/WrapActionBar.java
@@ -4,6 +4,7 @@ import android.app.ActionBar;
 import android.app.Activity;
 import android.view.MenuItem;
 
+@SuppressLint("NewApi")
 public class WrapActionBar {
     static {
         try {


### PR DESCRIPTION
Suppress compilation errors given by Android studio due to several invocations of Android APIs that are not yet existing in API level 9 (the minimum supported SDK version). For example, getActionBar(), setShowAsAction(), setDisplayHomeAsUpEnabled() are only interested in API Level 11, setHomeButtonEnabled() is introduced in API level 14.