### PR TITLE
Support launching Notepad from Shopping with SDK30.

### DIFF
--- a/NotePad/build.gradle
+++ b/NotePad/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 30
+    buildToolsVersion '30.0.3'
 
     defaultConfig {
         applicationId "org.openintents.notepad"
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 10084
         versionName "1.5.4"
     }

--- a/NotePad/src/main/AndroidManifest.xml
+++ b/NotePad/src/main/AndroidManifest.xml
@@ -40,6 +40,9 @@
   [10054] 1.1.1: 2009-05-16
   [10052] 1.1.0: 2009-02-02 -->
 
+  <queries>
+    <package android:name="org.openintents.shopping" />
+  </queries>
 
   <uses-feature
     android:name="android.hardware.touchscreen"

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:7.0.2'
         classpath 'com.novoda:gradle-android-command-plugin:1.4.0'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip


### PR DESCRIPTION
When switching targetSDK to 30 or higher, Notepad cannot be launched from Shopping any more. This PR has the fix for it.